### PR TITLE
feat: add uploading of answers

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,5 +1,5 @@
 import { Blockquote, Code, Em, Flex, Link, Strong, Text } from '@radix-ui/themes'
-import React, { FC } from 'react'
+import React, { FC, memo } from 'react'
 import { default as MarkdownRoot } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -7,7 +7,9 @@ interface MarkdownProps {
   children: string
 }
 
-const Markdown: FC<MarkdownProps> = ({ children }) => {
+// NOTE: Markdown has been memoized to prevent unnecessary re-renders when
+// sibling components change, as rending markdown that includes e.g. images is expensive.
+const Markdown: FC<MarkdownProps> = memo(({ children }) => {
   const componentMapping = {
     p(props) {
       return <Text as="p">{props.children}</Text>
@@ -45,6 +47,6 @@ const Markdown: FC<MarkdownProps> = ({ children }) => {
       </MarkdownRoot>
     </Flex>
   )
-}
+})
 
 export default Markdown

--- a/src/components/questionStructure/Task/types.ts
+++ b/src/components/questionStructure/Task/types.ts
@@ -3,6 +3,6 @@ import { TaskType } from './constants'
 export interface TaskBaseProps<V> {
   type: TaskType
   answer?: V
-  onAnswerUpdate: (value: V) => void
+  onAnswerUpdate: (value: string) => void
   disabled?: boolean
 }

--- a/src/components/questionStructure/Task/variants/CodeTask.tsx
+++ b/src/components/questionStructure/Task/variants/CodeTask.tsx
@@ -17,13 +17,13 @@ export const CodeTask: FC<CodeTaskProps> = ({
   lines = 5,
   disabled = false,
 }) => {
-  const [inputValue, setInputValue] = useState(answer)
-  useEffect(() => {
-    if (inputValue !== undefined) onAnswerUpdate(inputValue)
-  }, [inputValue, onAnswerUpdate])
+  // const [inputValue, setInputValue] = useState(answer)
+  // useEffect(() => {
+  //   if (inputValue !== undefined) onAnswerUpdate(inputValue)
+  // }, [inputValue, onAnswerUpdate])
   const commonProps = {
-    value: inputValue,
-    onChange: defaultOnChangeHandler(setInputValue),
+    value: answer,
+    onChange: defaultOnChangeHandler(onAnswerUpdate),
     placeholder: 'Your answer here…',
     disabled: disabled,
     variant: 'soft' as 'soft',

--- a/src/components/questionStructure/Task/variants/CodeTask.tsx
+++ b/src/components/questionStructure/Task/variants/CodeTask.tsx
@@ -17,10 +17,6 @@ export const CodeTask: FC<CodeTaskProps> = ({
   lines = 5,
   disabled = false,
 }) => {
-  // const [inputValue, setInputValue] = useState(answer)
-  // useEffect(() => {
-  //   if (inputValue !== undefined) onAnswerUpdate(inputValue)
-  // }, [inputValue, onAnswerUpdate])
   const commonProps = {
     value: answer,
     onChange: defaultOnChangeHandler(onAnswerUpdate),

--- a/src/components/questionStructure/Task/variants/EssayTask.tsx
+++ b/src/components/questionStructure/Task/variants/EssayTask.tsx
@@ -16,13 +16,14 @@ export const EssayTask: FC<EssayTaskProps> = ({
   lines = 5,
   disabled = false,
 }) => {
-  const [inputValue, setInputValue] = useState(answer)
-  useEffect(() => {
-    if (inputValue !== undefined) onAnswerUpdate(inputValue)
-  }, [inputValue, onAnswerUpdate])
+  // const [inputValue, setInputValue] = useState(answer)
+  // useEffect(() => {
+  //   if (inputValue !== undefined) onAnswerUpdate(inputValue)
+  // }, [inputValue, onAnswerUpdate])
+
   const commonProps = {
-    value: inputValue,
-    onChange: defaultOnChangeHandler(setInputValue),
+    value: answer,
+    onChange: defaultOnChangeHandler(onAnswerUpdate),
     placeholder: 'Your answer here…',
     disabled: disabled,
     variant: 'soft' as 'soft',

--- a/src/components/questionStructure/Task/variants/EssayTask.tsx
+++ b/src/components/questionStructure/Task/variants/EssayTask.tsx
@@ -16,11 +16,6 @@ export const EssayTask: FC<EssayTaskProps> = ({
   lines = 5,
   disabled = false,
 }) => {
-  // const [inputValue, setInputValue] = useState(answer)
-  // useEffect(() => {
-  //   if (inputValue !== undefined) onAnswerUpdate(inputValue)
-  // }, [inputValue, onAnswerUpdate])
-
   const commonProps = {
     value: answer,
     onChange: defaultOnChangeHandler(onAnswerUpdate),

--- a/src/components/questionStructure/Task/variants/FlagTask/index.tsx
+++ b/src/components/questionStructure/Task/variants/FlagTask/index.tsx
@@ -1,6 +1,6 @@
 import { Flex, TextField } from '@radix-ui/themes'
 import classnames from 'classnames'
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useCallback, useEffect, useState } from 'react'
 
 import { TaskType } from '../../constants'
 import { TaskBaseProps } from '../../types'
@@ -18,15 +18,14 @@ export const FlagTask: FC<FlagTaskProps> = ({
   disabled = false,
 }) => {
   const FLAG_LENGTH = 32
-  const [inputValue, setInputValue] = useState(answer)
-  useEffect(() => {
-    if (inputValue !== undefined) onAnswerUpdate(inputValue)
-  }, [inputValue, onAnswerUpdate])
 
-  function handleChange(e) {
-    const valueWithoutSpaces = e.target.value.replace(/\s+/g, '')
-    setInputValue(valueWithoutSpaces)
-  }
+  const handleChange = useCallback(
+    (e) => {
+      const valueWithoutSpaces = e.target.value.replace(/\s+/g, '')
+      onAnswerUpdate(valueWithoutSpaces)
+    },
+    [onAnswerUpdate]
+  )
 
   return (
     <Flex align="stretch">
@@ -37,7 +36,7 @@ export const FlagTask: FC<FlagTaskProps> = ({
       )}
       <TextField.Root
         disabled={disabled}
-        value={inputValue}
+        value={answer}
         onChange={handleChange}
         radius="none"
         type="text"

--- a/src/components/questionStructure/Task/variants/MCQ.tsx
+++ b/src/components/questionStructure/Task/variants/MCQ.tsx
@@ -1,6 +1,6 @@
 import { CheckboxGroup, RadioGroup } from '@radix-ui/themes'
 import { map } from 'lodash'
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useCallback, useEffect, useState } from 'react'
 
 import { TaskType } from '../constants'
 import { defaultOnChangeHandler } from '../index'
@@ -27,16 +27,12 @@ export const MCQOneTask: FC<MCQOneTaskProps> = ({
   choices,
   disabled = false,
 }) => {
-  const [inputValue, setInputValue] = useState(answer)
-  useEffect(() => {
-    if (inputValue !== undefined) onAnswerUpdate(inputValue)
-  }, [inputValue, onAnswerUpdate])
   return (
     <RadioGroup.Root
       variant="soft"
       disabled={disabled}
-      value={inputValue}
-      onClick={defaultOnChangeHandler(setInputValue)}
+      value={answer}
+      onClick={defaultOnChangeHandler(onAnswerUpdate)}
     >
       {map(choices, (o) => (
         <RadioGroup.Item key={o.value} value={o.value}>
@@ -52,21 +48,24 @@ export const MCQMultiTask: FC<MCQMultiTaskProps> = ({
   choices,
   disabled = false,
 }) => {
-  const [inputValue, setInputValue] = useState(answer ?? [])
-  useEffect(() => {
-    if (inputValue !== undefined) onAnswerUpdate(inputValue)
-  }, [inputValue, onAnswerUpdate])
-  const handleOnClick = (e) => {
-    const newAnswer = e.target.value
-    if (inputValue.includes(newAnswer)) setInputValue((vs) => vs.filter((v) => v !== newAnswer))
-    else setInputValue((vs) => [...vs, newAnswer])
-  }
+  const handleOnClick = useCallback(
+    (e) => {
+      const newAnswer = e.target.value
+      const oldAnswer = answer ?? []
+      const newAnswersArray = oldAnswer.includes(newAnswer)
+        ? oldAnswer.filter((v) => v !== newAnswer)
+        : [...oldAnswer, newAnswer]
+
+      onAnswerUpdate(newAnswersArray.join(','))
+    },
+    [answer, onAnswerUpdate]
+  )
 
   return (
     <CheckboxGroup.Root
       disabled={disabled}
       variant="soft"
-      defaultValue={inputValue}
+      defaultValue={answer}
       onClick={handleOnClick}
     >
       {map(choices, (o) => (

--- a/src/components/questionStructure/Task/variants/NumberTask.tsx
+++ b/src/components/questionStructure/Task/variants/NumberTask.tsx
@@ -1,29 +1,24 @@
 import { TextField } from '@radix-ui/themes'
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useCallback } from 'react'
 
 import { TaskType } from '../constants'
 import { TaskBaseProps } from '../types'
 
-export interface NumberTaskProps extends TaskBaseProps<number> {
+export interface NumberTaskProps extends TaskBaseProps<number | ''> {
   type: TaskType.INTEGER
 }
 
 export const NumberTask: FC<NumberTaskProps> = ({ answer, onAnswerUpdate, disabled = false }) => {
-  const [inputValue, setInputValue] = useState<number | ''>(answer !== undefined ? answer : '')
-  useEffect(() => {
-    if (inputValue !== '') onAnswerUpdate(inputValue)
-  }, [inputValue, onAnswerUpdate])
-
-  const handleChange = (e) => setInputValue(e.target.value ? Number(e.target.value) : '')
+  const handleChange = useCallback((e) => onAnswerUpdate(e.target.value ?? ''), [onAnswerUpdate])
 
   return (
     <TextField.Root
-      value={inputValue}
+      value={answer ?? ''}
       onChange={handleChange}
       type="number"
       variant="soft"
       disabled={disabled}
-      placeholder="Your answer here…"
+      placeholder="0"
     />
   )
 }

--- a/src/hooks/exam.ts
+++ b/src/hooks/exam.ts
@@ -31,8 +31,6 @@ export const useQuestionAnswers = (number: number | undefined) => {
   }, [number])
 
   const answersLookup: AnswerMap = useMemo(() => {
-    console.log('RERENDER')
-    console.log(answers)
     return buildResourceLookupTable(answers, 'answer')
   }, [answers])
 
@@ -50,15 +48,14 @@ export const useQuestionAnswers = (number: number | undefined) => {
       )
       newAnswers.push({ question, part, section, task, answer: newAnswer })
       setAnswers(newAnswers)
+      console.log(newAnswers)
     },
     [answers]
   )
 
   const saveAnswers = useCallback(() => {
     if (number === undefined) return
-    axiosInstance.post(routes.questionAnswers(number), answers).then(() => {
-      console.log('Saved!')
-    })
+    axiosInstance.post(routes.questionAnswers(number), answers).then(() => {})
   }, [answers, number])
 
   return { lookupAnswer, answersAreLoaded, setAnswer, saveAnswers }

--- a/src/hooks/exam.ts
+++ b/src/hooks/exam.ts
@@ -30,10 +30,11 @@ export const useQuestionAnswers = (number: number | undefined) => {
       .finally(() => setAnswersAreLoaded(true))
   }, [number])
 
-  const answersLookup: AnswerMap = useMemo(
-    () => buildResourceLookupTable(answers, 'answer'),
-    [answers]
-  )
+  const answersLookup: AnswerMap = useMemo(() => {
+    console.log('RERENDER')
+    console.log(answers)
+    return buildResourceLookupTable(answers, 'answer')
+  }, [answers])
 
   const lookupAnswer = useCallback(
     (question: number, part: number, section: number, task: number) =>
@@ -41,7 +42,19 @@ export const useQuestionAnswers = (number: number | undefined) => {
     [answersLookup]
   )
 
-  return { lookupAnswer, answersAreLoaded }
+  const setAnswer = useCallback(
+    (question: number, part: number, section: number, task: number, newAnswer: string) => {
+      const newAnswers = answers.filter(
+        (a) =>
+          !(a.question === question && a.part === part && a.section === section && a.task === task)
+      )
+      newAnswers.push({ question, part, section, task, answer: newAnswer })
+      setAnswers(newAnswers)
+    },
+    [answers]
+  )
+
+  return { lookupAnswer, answersAreLoaded, setAnswer }
 }
 
 export const useAssessmentSummary = () => {

--- a/src/hooks/exam.ts
+++ b/src/hooks/exam.ts
@@ -48,7 +48,6 @@ export const useQuestionAnswers = (number: number | undefined) => {
       )
       newAnswers.push({ question, part, section, task, answer: newAnswer })
       setAnswers(newAnswers)
-      console.log(newAnswers)
     },
     [answers]
   )

--- a/src/hooks/exam.ts
+++ b/src/hooks/exam.ts
@@ -54,7 +54,14 @@ export const useQuestionAnswers = (number: number | undefined) => {
     [answers]
   )
 
-  return { lookupAnswer, answersAreLoaded, setAnswer }
+  const saveAnswers = useCallback(() => {
+    if (number === undefined) return
+    axiosInstance.post(routes.questionAnswers(number), answers).then(() => {
+      console.log('Saved!')
+    })
+  }, [answers, number])
+
+  return { lookupAnswer, answersAreLoaded, setAnswer, saveAnswers }
 }
 
 export const useAssessmentSummary = () => {

--- a/src/pages/QuestionPage.tsx
+++ b/src/pages/QuestionPage.tsx
@@ -1,8 +1,7 @@
-import { Separator } from '@radix-ui/themes'
+import { Button, Separator } from '@radix-ui/themes'
 import { instanceToPlain } from 'class-transformer'
-import memoize from 'fast-memoize'
 import { map, sum } from 'lodash'
-import React, { FC, useMemo } from 'react'
+import React, { FC } from 'react'
 import { matchPath, useLocation } from 'react-router-dom'
 
 import Body from '../components/pageStructure/Body'
@@ -19,11 +18,13 @@ const QuestionPage: FC = () => {
   const pathMatch = matchPath({ path: '/questions/:number' }, pathname)
 
   const { question, questionIsLoaded } = useQuestion(Number(pathMatch?.params?.number))
-  const { lookupAnswer, setAnswer } = useQuestionAnswers(Number(pathMatch?.params?.number))
+  const { lookupAnswer, setAnswer, saveAnswers } = useQuestionAnswers(
+    Number(pathMatch?.params?.number)
+  )
 
   const handlerFactory =
     (question: number, part: number, section: number, task: number) => (newAnswer: string) => {
-      if (question === 1 && part === 1 && section === 1 && task === 2) {
+      if (question === 1 && part === 1 && section === 1) {
         console.log(
           `Question ${question}, Part ${part}, Section ${section}, Task ${task} updated to ${newAnswer}!`
         )
@@ -82,6 +83,9 @@ const QuestionPage: FC = () => {
             )
           })}
         </Question>
+        <Button size="4" color="green" type="submit" onClick={saveAnswers}>
+          Save Answers
+        </Button>
       </Body>
     </>
   )

--- a/src/pages/QuestionPage.tsx
+++ b/src/pages/QuestionPage.tsx
@@ -1,7 +1,8 @@
 import { Separator } from '@radix-ui/themes'
 import { instanceToPlain } from 'class-transformer'
+import memoize from 'fast-memoize'
 import { map, sum } from 'lodash'
-import React, { FC } from 'react'
+import React, { FC, useMemo } from 'react'
 import { matchPath, useLocation } from 'react-router-dom'
 
 import Body from '../components/pageStructure/Body'
@@ -18,13 +19,22 @@ const QuestionPage: FC = () => {
   const pathMatch = matchPath({ path: '/questions/:number' }, pathname)
 
   const { question, questionIsLoaded } = useQuestion(Number(pathMatch?.params?.number))
-  const { lookupAnswer } = useQuestionAnswers(Number(pathMatch?.params?.number))
+  const { lookupAnswer, setAnswer } = useQuestionAnswers(Number(pathMatch?.params?.number))
+
+  const handlerFactory =
+    (question: number, part: number, section: number, task: number) => (newAnswer: string) => {
+      if (question === 1 && part === 1 && section === 1 && task === 2) {
+        console.log(
+          `Question ${question}, Part ${part}, Section ${section}, Task ${task} updated to ${newAnswer}!`
+        )
+        setAnswer(question, part, section, task, newAnswer)
+      }
+    }
 
   if (!pathMatch || !questionIsLoaded) return <div>Placeholder</div>
   if (question === undefined) return <div>404</div>
 
   const questionID = Number(pathMatch.params.number)
-  const handler = (v) => {}
 
   return (
     <>
@@ -39,7 +49,7 @@ const QuestionPage: FC = () => {
                 partId={partID}
                 description={part.instructions}
                 marksContribution={sum(map(part.sections, 'maximumMark'))}
-                onSave={handler}
+                onSave={() => console.log(`Part ${partID} saved!`)} // TODO: Implement
               >
                 {Object.entries(part.sections).map(([sectionIDString, section], i) => {
                   const sectionID = Number(sectionIDString)
@@ -56,7 +66,8 @@ const QuestionPage: FC = () => {
                           <TaskFactory
                             key={i}
                             {...({
-                              onAnswerUpdate: handler,
+                              onAnswerUpdate: handlerFactory(questionID, partID, sectionID, taskID),
+                              //onAnswerUpdate: console.log,
                               ...instanceToPlain(task),
                               answer: parseAnswer(answer, task.type),
                             } as TaskProps)}

--- a/src/pages/QuestionPage.tsx
+++ b/src/pages/QuestionPage.tsx
@@ -24,12 +24,7 @@ const QuestionPage: FC = () => {
 
   const handlerFactory =
     (question: number, part: number, section: number, task: number) => (newAnswer: string) => {
-      if (question === 1 && part === 1 && section === 1) {
-        console.log(
-          `Question ${question}, Part ${part}, Section ${section}, Task ${task} updated to ${newAnswer}!`
-        )
-        setAnswer(question, part, section, task, newAnswer)
-      }
+      setAnswer(question, part, section, task, newAnswer)
     }
 
   if (!pathMatch || !questionIsLoaded) return <div>Placeholder</div>
@@ -68,7 +63,6 @@ const QuestionPage: FC = () => {
                             key={i}
                             {...({
                               onAnswerUpdate: handlerFactory(questionID, partID, sectionID, taskID),
-                              //onAnswerUpdate: console.log,
                               ...instanceToPlain(task),
                               answer: parseAnswer(answer, task.type),
                             } as TaskProps)}

--- a/src/tests/components/questionStructure/TaskVariants.test.tsx
+++ b/src/tests/components/questionStructure/TaskVariants.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/extend-expect'
 import { fireEvent, render, screen } from '@testing-library/react'
-import React from 'react'
+import React, { useState } from 'react'
 
 import { TaskType } from '../../../components/questionStructure/Task/constants'
 import { CodeTask } from '../../../components/questionStructure/Task/variants/CodeTask'
@@ -58,7 +58,7 @@ describe('NumberTask', () => {
     render(<NumberTask type={TaskType.INTEGER} answer={0} onAnswerUpdate={handleChange} />)
     const input = screen.getByRole('spinbutton')
     fireEvent.change(input, { target: { value: 5 } })
-    expect(handleChange).toHaveBeenCalledWith(5)
+    expect(handleChange).toHaveBeenCalledWith('5')
   })
 
   it('renders as disabled', () => {
@@ -167,22 +167,33 @@ describe('MCQMultiTask', () => {
     expect(screen.getByLabelText('Option 2')).toBeInTheDocument()
   })
 
-  it('handles multiple option selection', () => {
-    const handleChange = jest.fn()
-    render(
+  const TestMCQWrapper = ({ initialAnswer = [], onAnswerUpdate }) => {
+    const [answer, setAnswer] = useState(initialAnswer)
+
+    const handleAnswerUpdate = (newAnswer) => {
+      setAnswer(newAnswer.split(','))
+      onAnswerUpdate(newAnswer)
+    }
+
+    return (
       <MCQMultiTask
         type={TaskType.MULTIPLE_CHOICE_SELECT_SEVERAL}
-        answer={[]}
-        onAnswerUpdate={handleChange}
+        answer={answer}
+        onAnswerUpdate={handleAnswerUpdate}
         choices={options}
       />
     )
+  }
+
+  it('handles multiple option selection', () => {
+    const handleChange = jest.fn()
+    render(<TestMCQWrapper onAnswerUpdate={handleChange} initialAnswer={[]} />)
     const option1 = screen.getByLabelText('Option 1')
     const option2 = screen.getByLabelText('Option 2')
     fireEvent.click(option1)
-    expect(handleChange).toHaveBeenCalledWith(['1'])
+    expect(handleChange).toHaveBeenCalledWith('1')
     fireEvent.click(option2)
-    expect(handleChange).toHaveBeenCalledWith(['1', '2'])
+    expect(handleChange).toHaveBeenCalledWith('1,2')
   })
 
   it('renders as disabled', () => {

--- a/src/utils/answers.ts
+++ b/src/utils/answers.ts
@@ -23,7 +23,7 @@ export function buildResourceLookupTable<T extends AnswerBookRootResource>(
 export function parseAnswer(answer: string, targetTaskType: TaskType) {
   switch (targetTaskType) {
     case TaskType.INTEGER:
-      return Number(answer)
+      return answer === '' ? answer : Number(answer)
     case TaskType.MULTIPLE_CHOICE_SELECT_SEVERAL:
       return answer === '' ? [] : answer.split(',')
     default:

--- a/src/utils/answers.ts
+++ b/src/utils/answers.ts
@@ -25,7 +25,7 @@ export function parseAnswer(answer: string, targetTaskType: TaskType) {
     case TaskType.INTEGER:
       return Number(answer)
     case TaskType.MULTIPLE_CHOICE_SELECT_SEVERAL:
-      return answer.split(',')
+      return answer === '' ? [] : answer.split(',')
     default:
       return answer
   }


### PR DESCRIPTION
Adds the ability to upload answers students write to the backend.

It adds a "save" button to save all the answers for a whole question at a time, which are fetched on page load.

There are also some performance improvements to prevent issues with long render times & render loops encountered whilst writing the code.

Missing:
1. Autosave
2. Saving on a granularity smaller than a whole question
3. Better data handling - have had to change state to always use a string underneath as that's what the API expects, even for e.g. checkboxes etc.