### PR TITLE
fix: make marks box reactive when adding new marks

### DIFF
--- a/src/hooks/marking.ts
+++ b/src/hooks/marking.ts
@@ -66,7 +66,10 @@ export const useStudentMarks = (studentID: string) => {
       .post(routes.studentMarks(studentID), instanceToPlain(newMark))
       .then(({ data }) => {
         const newMark = plainToInstance(MarkRoot, data)
-        setMarks((ms) => ms.map((m) => (m.id === newMark.id ? newMark : m)))
+        setMarks((ms) => {
+          const otherMarks = ms.filter((m) => m.id !== newMark.id)
+          return [...otherMarks, newMark]
+        })
       })
   }
 


### PR DESCRIPTION
Ensure that when marks are added for the first time they show up in the UI as they added, instead of requiring a page refresh.
