### PR TITLE
feat: store handwriting

### DIFF
--- a/src/components/questionStructure/Task/variants/HandwritingTask/Canvas.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/Canvas.tsx
@@ -13,6 +13,7 @@ import React, {
 
 import { ConfirmDialog } from '../../../../ConfirmDialog'
 import useLiveUpdates from './live-updates.hook'
+import { HandwritingAnswer } from './types'
 
 const stopEvent = (e: SyntheticEvent | Event) => {
   e.preventDefault()
@@ -45,9 +46,20 @@ const ALLOWED_TOOL_SHORTCUTS = [
 ]
 
 const Canvas: React.FC<CanvasProps> = ({ username, onAnswerChange }) => {
-  const { updateStrokes } = useLiveUpdates(username, onAnswerChange)
   const [excalidrawAPI, setExcalidrawAPI] = useState<ExcalidrawImperativeAPI | null>(null)
   const [clearDialogOpen, setClearDialogOpen] = useState(false)
+
+  const updateHandwriting = useCallback(
+    (latex: string) => {
+      const result: HandwritingAnswer = {
+        latex,
+        excalidraw: excalidrawAPI?.getSceneElements(),
+      }
+      onAnswerChange(JSON.stringify(result))
+    },
+    [excalidrawAPI, onAnswerChange]
+  )
+  const { updateStrokes } = useLiveUpdates(username, updateHandwriting)
 
   const clearCanvas = useCallback(() => {
     updateStrokes({ elements: [] })

--- a/src/components/questionStructure/Task/variants/HandwritingTask/Canvas.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/Canvas.tsx
@@ -58,7 +58,7 @@ const Canvas: React.FC<CanvasProps> = ({ username, onAnswerChange, initialData }
     (latex: string) => {
       const result: HandwritingAnswer = {
         latex,
-        excalidraw: {
+        raw: {
           elements: excalidrawAPI?.getSceneElements() ?? [],
           appState: excalidrawAPI?.getAppState(),
         },

--- a/src/components/questionStructure/Task/variants/HandwritingTask/Canvas.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/Canvas.tsx
@@ -1,6 +1,7 @@
 import { Excalidraw, MainMenu } from '@excalidraw/excalidraw'
 import { getDefaultAppState } from '@excalidraw/excalidraw/main'
 import { ClipboardData } from '@excalidraw/excalidraw/types/clipboard'
+import { ExcalidrawElement } from '@excalidraw/excalidraw/types/element/types'
 import { AppState, ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types/types'
 import { Box } from '@radix-ui/themes'
 import React, {
@@ -24,6 +25,7 @@ const stopEvent = (e: SyntheticEvent | Event) => {
 interface CanvasProps {
   username: string
   onAnswerChange: (value: string) => void
+  initialData: readonly ExcalidrawElement[]
 }
 
 // Excalidraw keyboard shortcuts we allow in the canvas:
@@ -46,7 +48,7 @@ const ALLOWED_TOOL_SHORTCUTS = [
   'Digit7', // pen
 ]
 
-const Canvas: React.FC<CanvasProps> = ({ username, onAnswerChange }) => {
+const Canvas: React.FC<CanvasProps> = ({ username, onAnswerChange, initialData }) => {
   const [excalidrawAPI, setExcalidrawAPI] = useState<ExcalidrawImperativeAPI | null>(null)
   const [clearDialogOpen, setClearDialogOpen] = useState(false)
 
@@ -144,7 +146,7 @@ const Canvas: React.FC<CanvasProps> = ({ username, onAnswerChange }) => {
         UIOptions={{ tools: { image: false } }}
         gridModeEnabled
         excalidrawAPI={setExcalidrawAPI}
-        // initialData={excalidrawData}
+        initialData={{ elements: initialData }}
         onPaste={pasteHandler}
       >
         <MainMenu>

--- a/src/components/questionStructure/Task/variants/HandwritingTask/Canvas.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/Canvas.tsx
@@ -1,4 +1,5 @@
 import { Excalidraw, MainMenu } from '@excalidraw/excalidraw'
+import { getDefaultAppState } from '@excalidraw/excalidraw/main'
 import { ClipboardData } from '@excalidraw/excalidraw/types/clipboard'
 import { AppState, ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types/types'
 import { Box } from '@radix-ui/themes'
@@ -53,7 +54,10 @@ const Canvas: React.FC<CanvasProps> = ({ username, onAnswerChange }) => {
     (latex: string) => {
       const result: HandwritingAnswer = {
         latex,
-        excalidraw: excalidrawAPI?.getSceneElements(),
+        excalidraw: {
+          elements: excalidrawAPI?.getSceneElements() ?? [],
+          appState: excalidrawAPI?.getAppState() ?? getDefaultAppState(),
+        },
       }
       onAnswerChange(JSON.stringify(result))
     },

--- a/src/components/questionStructure/Task/variants/HandwritingTask/Canvas.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/Canvas.tsx
@@ -1,5 +1,4 @@
 import { Excalidraw, MainMenu } from '@excalidraw/excalidraw'
-import { getDefaultAppState } from '@excalidraw/excalidraw/main'
 import { ClipboardData } from '@excalidraw/excalidraw/types/clipboard'
 import { ExcalidrawElement } from '@excalidraw/excalidraw/types/element/types'
 import { AppState, ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types/types'
@@ -25,7 +24,10 @@ const stopEvent = (e: SyntheticEvent | Event) => {
 interface CanvasProps {
   username: string
   onAnswerChange: (value: string) => void
-  initialData: readonly ExcalidrawElement[]
+  initialData: {
+    elements?: readonly ExcalidrawElement[]
+    appState?: AppState
+  }
 }
 
 // Excalidraw keyboard shortcuts we allow in the canvas:
@@ -58,7 +60,7 @@ const Canvas: React.FC<CanvasProps> = ({ username, onAnswerChange, initialData }
         latex,
         excalidraw: {
           elements: excalidrawAPI?.getSceneElements() ?? [],
-          appState: excalidrawAPI?.getAppState() ?? getDefaultAppState(),
+          appState: excalidrawAPI?.getAppState(),
         },
       }
       onAnswerChange(JSON.stringify(result))
@@ -146,7 +148,10 @@ const Canvas: React.FC<CanvasProps> = ({ username, onAnswerChange, initialData }
         UIOptions={{ tools: { image: false } }}
         gridModeEnabled
         excalidrawAPI={setExcalidrawAPI}
-        initialData={{ elements: initialData }}
+        initialData={{
+          ...initialData,
+          appState: { ...initialData.appState, collaborators: new Map() },
+        }}
         onPaste={pasteHandler}
       >
         <MainMenu>

--- a/src/components/questionStructure/Task/variants/HandwritingTask/HandwritingEditor.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/HandwritingEditor.tsx
@@ -5,27 +5,28 @@ import React from 'react'
 import Markdown from '../../../../Markdown'
 import Canvas from './Canvas'
 import './handwritingEditor.css'
+import { HandwritingAnswer } from './types'
 
 interface HandwritingEditorProps {
   username: string
-  latex: string
+  answer?: HandwritingAnswer
   onAnswerChange: (value: string) => void
 }
 
 const HandwritingEditor: React.FC<HandwritingEditorProps> = ({
   username,
-  latex,
+  answer,
   onAnswerChange,
 }) => {
   return (
     <Flex direction="column" flexGrow="1" align="center" gap="3">
       <Card className="mathjax-card">
         <Box p="3">
-          <MathJax>{`\\( ${latex} \\)`}</MathJax>
+          <MathJax>{`\\( ${answer?.latex} \\)`}</MathJax>
         </Box>
       </Card>
       <Card className="excalidraw-canvas-card">
-        <Canvas username={username} onAnswerChange={onAnswerChange} />
+        <Canvas username={username} onAnswerChange={onAnswerChange} initialData={answer?.excalidraw?.elements ?? []} />
       </Card>
     </Flex>
   )

--- a/src/components/questionStructure/Task/variants/HandwritingTask/HandwritingEditor.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/HandwritingEditor.tsx
@@ -25,9 +25,7 @@ const HandwritingEditor: React.FC<HandwritingEditorProps> = ({
           <MathJax>{`\\( ${answer?.latex} \\)`}</MathJax>
         </Box>
       </Card>
-      <Card
-        className="excalidraw-canvas-card"
-      >
+      <Card className="excalidraw-canvas-card">
         <Canvas
           username={username}
           onAnswerChange={onAnswerChange}

--- a/src/components/questionStructure/Task/variants/HandwritingTask/HandwritingEditor.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/HandwritingEditor.tsx
@@ -25,8 +25,15 @@ const HandwritingEditor: React.FC<HandwritingEditorProps> = ({
           <MathJax>{`\\( ${answer?.latex} \\)`}</MathJax>
         </Box>
       </Card>
-      <Card className="excalidraw-canvas-card">
-        <Canvas username={username} onAnswerChange={onAnswerChange} initialData={answer?.excalidraw?.elements ?? []} />
+      <Card
+        className="excalidraw-canvas-card"
+      >
+        <Canvas
+          username={username}
+          onAnswerChange={onAnswerChange}
+          // @ts-expect-error: this is not just initialData
+          initialData={answer?.excalidraw ?? {}}
+        />
       </Card>
     </Flex>
   )

--- a/src/components/questionStructure/Task/variants/HandwritingTask/HandwritingEditor.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/HandwritingEditor.tsx
@@ -22,7 +22,7 @@ const HandwritingEditor: React.FC<HandwritingEditorProps> = ({
     <Flex direction="column" flexGrow="1" align="center" gap="3">
       <Card className="mathjax-card">
         <Box p="3">
-          <MathJax>{`\\( ${answer?.latex} \\)`}</MathJax>
+          <MathJax>{`\\( ${answer?.latex ?? ''} \\)`}</MathJax>
         </Box>
       </Card>
       <Card className="excalidraw-canvas-card">

--- a/src/components/questionStructure/Task/variants/HandwritingTask/HandwritingEditor.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/HandwritingEditor.tsx
@@ -29,8 +29,8 @@ const HandwritingEditor: React.FC<HandwritingEditorProps> = ({
         <Canvas
           username={username}
           onAnswerChange={onAnswerChange}
-          // @ts-expect-error: this is not just initialData
-          initialData={answer?.excalidraw ?? {}}
+          // @ts-expect-error: Types of initialData and answer are essentially the same but TypeScript doesn't recognize it
+          initialData={answer?.raw ?? {}}
         />
       </Card>
     </Flex>

--- a/src/components/questionStructure/Task/variants/HandwritingTask/ViewOnlyCanvas.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/ViewOnlyCanvas.tsx
@@ -24,7 +24,7 @@ export const ViewOnlyCanvas: React.FC<ViewOnlyCanvasProps> = ({ initialData }) =
     })
   }, [excalidrawAPI, initialData])
 
-  return initialData && initialData?.length ? (
+  return (
     <Card>
       <Box
         className="excalidraw-view-container excalidraw-box"
@@ -38,5 +38,5 @@ export const ViewOnlyCanvas: React.FC<ViewOnlyCanvasProps> = ({ initialData }) =
         />
       </Box>
     </Card>
-  ) : null
+  )
 }

--- a/src/components/questionStructure/Task/variants/HandwritingTask/ViewOnlyCanvas.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/ViewOnlyCanvas.tsx
@@ -1,13 +1,11 @@
 import { Excalidraw } from '@excalidraw/excalidraw'
-import {
-  ExcalidrawImperativeAPI,
-  ExcalidrawInitialDataState,
-} from '@excalidraw/excalidraw/types/types'
+import { ExcalidrawElement } from '@excalidraw/excalidraw/types/element/types'
+import { ExcalidrawImperativeAPI } from '@excalidraw/excalidraw/types/types'
 import { Box, Card } from '@radix-ui/themes'
 import React, { useEffect, useState } from 'react'
 
 interface ViewOnlyCanvasProps {
-  initialData: ExcalidrawInitialDataState
+  initialData: readonly ExcalidrawElement[]
 }
 
 export const ViewOnlyCanvas: React.FC<ViewOnlyCanvasProps> = ({ initialData }) => {
@@ -21,10 +19,26 @@ export const ViewOnlyCanvas: React.FC<ViewOnlyCanvasProps> = ({ initialData }) =
     })
   }, [excalidrawAPI])
 
-  return initialData && initialData.elements?.length ? (
+  useEffect(() => {
+    if (excalidrawAPI && initialData) {
+      excalidrawAPI.updateScene({
+        elements: initialData,
+      })
+    }
+  }, [excalidrawAPI, initialData])
+
+  return initialData && initialData?.length ? (
     <Card>
-      <Box className="excalidraw-view-container excalidraw-box">
-        <Excalidraw excalidrawAPI={setExcalidrawAPI} viewModeEnabled initialData={initialData} />
+      <Box
+        className="excalidraw-view-container excalidraw-box"
+        height="calc(100% - 4px)"
+        style={{ margin: '2px' }}
+      >
+        <Excalidraw
+          excalidrawAPI={setExcalidrawAPI}
+          viewModeEnabled
+          initialData={{ elements: initialData }}
+        />
       </Box>
     </Card>
   ) : null

--- a/src/components/questionStructure/Task/variants/HandwritingTask/ViewOnlyCanvas.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/ViewOnlyCanvas.tsx
@@ -26,11 +26,7 @@ export const ViewOnlyCanvas: React.FC<ViewOnlyCanvasProps> = ({ initialData }) =
 
   return (
     <Card>
-      <Box
-        className="excalidraw-view-container excalidraw-box"
-        height="calc(100% - 4px)"
-        style={{ margin: '2px' }}
-      >
+      <Box className="excalidraw-view-container excalidraw-box">
         <Excalidraw
           excalidrawAPI={setExcalidrawAPI}
           viewModeEnabled

--- a/src/components/questionStructure/Task/variants/HandwritingTask/ViewOnlyCanvas.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/ViewOnlyCanvas.tsx
@@ -12,19 +12,16 @@ export const ViewOnlyCanvas: React.FC<ViewOnlyCanvasProps> = ({ initialData }) =
   const [excalidrawAPI, setExcalidrawAPI] = useState<ExcalidrawImperativeAPI | null>(null)
 
   useEffect(() => {
-    setTimeout(() => {
-      excalidrawAPI?.scrollToContent(undefined, {
-        fitToContent: true,
-      })
-    })
-  }, [excalidrawAPI])
-
-  useEffect(() => {
     if (excalidrawAPI && initialData) {
       excalidrawAPI.updateScene({
         elements: initialData,
       })
     }
+    setTimeout(() => {
+      excalidrawAPI?.scrollToContent(undefined, {
+        fitToContent: true,
+      })
+    })
   }, [excalidrawAPI, initialData])
 
   return initialData && initialData?.length ? (

--- a/src/components/questionStructure/Task/variants/HandwritingTask/index.scss
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/index.scss
@@ -62,7 +62,7 @@
 }
 
 .excalidraw-box {
-  margin: '2px';
+  margin: 2px;
   height: calc(100% - 4px);
 }
 

--- a/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
@@ -44,7 +44,7 @@ export const HandwritingTask: FC<HandwritingTaskProps> = ({
       <Dialog.Content className="excalidraw-dialog-content">
         <Flex direction="column" height="100%" gap="3">
           <HandwritingEditor
-            latex={answer?.latex ?? ''}
+            answer={answer}
             onAnswerChange={onAnswerUpdate}
             username={username}
           />

--- a/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
@@ -1,6 +1,7 @@
 import { Pencil2Icon } from '@radix-ui/react-icons'
 import { Button, Card, Dialog, Flex } from '@radix-ui/themes'
 import { MathJax } from 'better-react-mathjax'
+import { isEmpty } from 'lodash'
 import { FC } from 'react'
 import { useParams } from 'react-router-dom'
 
@@ -26,7 +27,9 @@ export const HandwritingTask: FC<HandwritingTaskProps> = ({
   return (
     <Dialog.Root>
       <Dialog.Trigger>
-        <ViewOnlyCanvas initialData={answer?.excalidraw?.elements ?? []} />
+        {!isEmpty(answer?.excalidraw?.elements) && (
+          <ViewOnlyCanvas initialData={answer!.excalidraw.elements} />
+        )}
       </Dialog.Trigger>
       <Flex gap="3" align="center">
         <Card className="latex-preview">

--- a/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
@@ -11,6 +11,10 @@ import HandwritingEditor from './HandwritingEditor'
 import { ViewOnlyCanvas } from './ViewOnlyCanvas'
 import './index.scss'
 
+export interface HandwritingAnswer {
+  excalidraw: any
+  latex: string
+}
 export interface HandwritingTaskProps extends TaskBaseProps<string> {
   type: TaskType.PROCESSED_HANDWRITING
 }
@@ -43,7 +47,7 @@ export const HandwritingTask: FC<HandwritingTaskProps> = ({
       <Dialog.Content className="excalidraw-dialog-content">
         <Flex direction="column" height="100%" gap="3">
           <HandwritingEditor
-            latex={answer ?? ''}
+            latex={answer?.latex ?? ''}
             onAnswerChange={onAnswerUpdate}
             username={username}
           />

--- a/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
@@ -43,11 +43,7 @@ export const HandwritingTask: FC<HandwritingTaskProps> = ({
 
       <Dialog.Content className="excalidraw-dialog-content">
         <Flex direction="column" height="100%" gap="3">
-          <HandwritingEditor
-            answer={answer}
-            onAnswerChange={onAnswerUpdate}
-            username={username}
-          />
+          <HandwritingEditor answer={answer} onAnswerChange={onAnswerUpdate} username={username} />
           <Flex justify="end">
             <Dialog.Close>
               <Button>Save LaTeX</Button>

--- a/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
@@ -27,9 +27,7 @@ export const HandwritingTask: FC<HandwritingTaskProps> = ({
   return (
     <Dialog.Root>
       <Dialog.Trigger>
-        {!isEmpty(answer?.excalidraw?.elements) && (
-          <ViewOnlyCanvas initialData={answer!.excalidraw.elements} />
-        )}
+        {!isEmpty(answer?.raw?.elements) && <ViewOnlyCanvas initialData={answer!.raw.elements} />}
       </Dialog.Trigger>
       <Flex gap="3" align="center">
         <Card className="latex-preview">

--- a/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
@@ -10,12 +10,9 @@ import { TaskBaseProps } from '../../types'
 import HandwritingEditor from './HandwritingEditor'
 import { ViewOnlyCanvas } from './ViewOnlyCanvas'
 import './index.scss'
+import { HandwritingAnswer } from './types'
 
-export interface HandwritingAnswer {
-  excalidraw: any
-  latex: string
-}
-export interface HandwritingTaskProps extends TaskBaseProps<string> {
+export interface HandwritingTaskProps extends TaskBaseProps<HandwritingAnswer> {
   type: TaskType.PROCESSED_HANDWRITING
 }
 

--- a/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
@@ -26,13 +26,15 @@ export const HandwritingTask: FC<HandwritingTaskProps> = ({
 
   return (
     <Dialog.Root>
-      <Dialog.Trigger>
-        {!isEmpty(answer?.raw?.elements) && <ViewOnlyCanvas initialData={answer!.raw.elements} />}
-      </Dialog.Trigger>
+      {!isEmpty(answer?.raw?.elements) && (
+        <Dialog.Trigger>
+          <ViewOnlyCanvas initialData={answer!.raw.elements} />
+        </Dialog.Trigger>
+      )}
       <Flex gap="3" align="center">
         <Card className="latex-preview">
           <Flex p="3">
-            <MathJax>{answer ? `\\( ${answer} \\)` : 'No Answer'}</MathJax>
+            <MathJax>{answer?.latex ? `\\( ${answer.latex} \\)` : 'No Answer'}</MathJax>
           </Flex>
         </Card>
         <Dialog.Trigger>

--- a/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/index.tsx
@@ -26,7 +26,7 @@ export const HandwritingTask: FC<HandwritingTaskProps> = ({
   return (
     <Dialog.Root>
       <Dialog.Trigger>
-        <ViewOnlyCanvas initialData={{}} />
+        <ViewOnlyCanvas initialData={answer?.excalidraw?.elements ?? []} />
       </Dialog.Trigger>
       <Flex gap="3" align="center">
         <Card className="latex-preview">

--- a/src/components/questionStructure/Task/variants/HandwritingTask/types.ts
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/types.ts
@@ -1,0 +1,4 @@
+export interface HandwritingAnswer {
+  excalidraw: any
+  latex: string
+}

--- a/src/components/questionStructure/Task/variants/HandwritingTask/types.ts
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/types.ts
@@ -4,7 +4,7 @@ import { AppState } from '@excalidraw/excalidraw/types/types'
 export interface HandwritingAnswer {
   excalidraw: {
     elements: readonly ExcalidrawElement[]
-    appState: Omit<AppState, 'offsetTop' | 'offsetLeft' | 'width' | 'height'>
+    appState?: Omit<AppState, 'offsetTop' | 'offsetLeft' | 'width' | 'height'>
   }
   latex: string
 }

--- a/src/components/questionStructure/Task/variants/HandwritingTask/types.ts
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/types.ts
@@ -2,7 +2,7 @@ import { ExcalidrawElement } from '@excalidraw/excalidraw/types/element/types'
 import { AppState } from '@excalidraw/excalidraw/types/types'
 
 export interface HandwritingAnswer {
-  excalidraw: {
+  raw: {
     elements: readonly ExcalidrawElement[]
     appState?: Omit<AppState, 'offsetTop' | 'offsetLeft' | 'width' | 'height'>
   }

--- a/src/components/questionStructure/Task/variants/HandwritingTask/types.ts
+++ b/src/components/questionStructure/Task/variants/HandwritingTask/types.ts
@@ -1,4 +1,10 @@
+import { ExcalidrawElement } from '@excalidraw/excalidraw/types/element/types'
+import { AppState } from '@excalidraw/excalidraw/types/types'
+
 export interface HandwritingAnswer {
-  excalidraw: any
+  excalidraw: {
+    elements: readonly ExcalidrawElement[]
+    appState: Omit<AppState, 'offsetTop' | 'offsetLeft' | 'width' | 'height'>
+  }
   latex: string
 }

--- a/src/utils/answers.ts
+++ b/src/utils/answers.ts
@@ -26,6 +26,8 @@ export function parseAnswer(answer: string, targetTaskType: TaskType) {
       return answer === '' ? answer : Number(answer)
     case TaskType.MULTIPLE_CHOICE_SELECT_SEVERAL:
       return answer === '' ? [] : answer.split(',')
+    case TaskType.PROCESSED_HANDWRITING:
+      return answer === '' ? { excalidraw: null, latex: '' } : JSON.parse(answer)
     default:
       return answer
   }


### PR DESCRIPTION
- Add storing and loading of canvas data (strokes and app state)
  - This is done fully on the frontend by using a JSON string as the answer sent to be stored in the answer table